### PR TITLE
Add global option to disable auto highlighting.

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -377,7 +377,7 @@ script = script[script.length - 1];
 if (script) {
 	_.filename = script.src;
 
-	if (document.addEventListener && !script.hasAttribute('data-manual')) {
+	if (document.addEventListener && !script.hasAttribute('data-manual') && !window.PRISM_JS_MANUAL) {
 		document.addEventListener('DOMContentLoaded', _.highlightAll);
 	}
 }


### PR DESCRIPTION
When bundling Prism.js with other libraries or loading it via a loader, it is pretty awkward to add the data-manual, this option helps disabling Prism auto highlighting before it is loaded.