### PR TITLE
make comment non-greedy in handlebars

### DIFF
--- a/components/prism-handlebars.js
+++ b/components/prism-handlebars.js
@@ -35,7 +35,7 @@
 	// surround markup
 	Prism.languages.insertBefore('handlebars', 'tag', {
 		'handlebars-comment': {
-			pattern: /\{\{![\w\W]*\}\}/g,
+			pattern: /\{\{![\w\W]*?\}\}/g,
 			alias: ['handlebars','comment']
 		}
 	});


### PR DESCRIPTION
When a comment is used inside a document, the document was marked as comment from the start of the comment until last occurrence of `}}`. This fixes that behavior. 