### PR TITLE
Fix single-string issue for Eiffel.

### DIFF
--- a/components/prism-eiffel.js
+++ b/components/prism-eiffel.js
@@ -1,11 +1,11 @@
 Prism.languages.eiffel = {
 	'string': [
+		// Single-line string
+		/"(?:%\s+%|%"|.)*?"/,
 		// Aligned-verbatim-strings
 		/"([^[]*)\[[\s\S]+?\]\1"/,
 		// Non-aligned-verbatim-strings
-		/"([^{]*)\{[\s\S]+?\}\1"/,
-		// Single-line string
-		/"(?:%\s+%|%"|.)*?"/
+		/"([^{]*)\{[\s\S]+?\}\1"/
 	],
 	// (comments including quoted strings not supported)
 	'comment': /--.*/,


### PR DESCRIPTION
Fix the reported issue https://github.com/Conaclos/prism/issues/2.

The use of the single-line string ``` "[]" ``` is interpreted as an aligned verbatim string (multi-line string).

The change of the order of regex handling enables to fix this issue.